### PR TITLE
refactor: use faker instead of benmaruchu/faker lib

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@
 
 /* dependencies */
 const _ = require('lodash');
-const faker = require('@benmaruchu/faker');
+const faker = require('faker');
 const { mergeObjects } = require('@lykmapipo/common');
 const { copyInstance } = require('@lykmapipo/mongoose-common');
 
@@ -182,8 +182,8 @@ function generate(schemaTypeOptions) {
         const uniqueOptns = { maxTime: MAX_TIME, maxRetries: MAX_RETRIES };
         value = (
           isUnique ?
-          faker.unique(value, undefined, uniqueOptns) :
-          value()
+            faker.unique(value, undefined, uniqueOptns) :
+            value()
         );
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,8 @@
     "@benmaruchu/faker": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@benmaruchu/faker/-/faker-4.3.0.tgz",
-      "integrity": "sha512-aT7+EnSqjfDuzM8pxhS7ckoaFLDf/0ThJ86dmzS8+dVHR7p5mi+WpWBsmYpFmTnKAbIeqpiDgCn3DY3zISWbAg=="
+      "integrity": "sha512-aT7+EnSqjfDuzM8pxhS7ckoaFLDf/0ThJ86dmzS8+dVHR7p5mi+WpWBsmYpFmTnKAbIeqpiDgCn3DY3zISWbAg==",
+      "dev": true
     },
     "@lykmapipo/common": {
       "version": "0.38.2",
@@ -1235,6 +1236,11 @@
           }
         }
       }
+    },
+    "faker": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-5.1.0.tgz",
+      "integrity": "sha512-RrWKFSSA/aNLP0g3o2WW1Zez7/MnMr7xkiZmoCfAGZmdkDQZ6l2KtuXHN5XjdvpRjDl8+3vf+Rrtl06Z352+Mw=="
     },
     "faye-websocket": {
       "version": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
     "mongoose": ">=5.9.28"
   },
   "dependencies": {
-    "@benmaruchu/faker": ">=4.3.0",
     "@lykmapipo/common": ">=0.38.2",
     "@lykmapipo/mongoose-common": ">=0.38.4",
+    "faker": "^5.1.0",
     "lodash": ">=4.17.19"
   }
 }


### PR DESCRIPTION
Hi @lykmapipo, I have update the faker dependency to use the original faker since the development and release circle as of now is more active compare to the time we opt to maintain a different distribution.

Thanks